### PR TITLE
Pin github/codeql-action to SHA

### DIFF
--- a/.github/workflows/codeql-javascript-typescript.yml
+++ b/.github/workflows/codeql-javascript-typescript.yml
@@ -61,7 +61,7 @@ jobs:
         
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -89,6 +89,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Pin `github/codeql-action/init@v4`, `github/codeql-action/analyze@v4`, and `github/codeql-action/autobuild@v4` (where applicable) to verified commit SHA.

- `github/codeql-action/*@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2`

This SHA matches the version already pinned in 47 other repos in the org.